### PR TITLE
fix: preserve Unicode prefixes in exported filenames

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -175,7 +175,7 @@ export function generateFileName(title: string): string {
 
     // CRITICAL: Remove special characters from the beginning
     // This fixes issues like ".htaccess" becoming an invisible file
-    fileName = fileName.replace(/^[^\w\d\s]+/, ""); // Remove non-alphanumeric at start
+    fileName = fileName.replace(/^[^\p{L}\p{N}\s]+/u, ""); // Remove non-letter/number characters at start
 
     // Clean up any remaining problematic patterns
     fileName = fileName

--- a/src/utils/conversation-filename.test.ts
+++ b/src/utils/conversation-filename.test.ts
@@ -19,6 +19,17 @@ describe("conversation filename length policy", () => {
         expect(name).toBe("Short title");
     });
 
+    it("preserves non-ASCII letters at the beginning of titles", () => {
+        const name = generateConversationFileName(
+            "Ошибка Ambiguous project name",
+            1_700_000_000,
+            false,
+            "YYYY-MM-DD"
+        );
+
+        expect(name).toBe("Ошибка Ambiguous project name");
+    });
+
     it("truncates long ASCII titles to the configured byte budget", () => {
         const longTitle = "A".repeat(300);
         const maxBaseBytes = CONVERSATION_NOTE_FILENAME_MAX_BYTES - 3;
@@ -46,6 +57,7 @@ describe("conversation filename length policy", () => {
         );
 
         expect(getUtf8ByteLength(name)).toBeLessThanOrEqual(maxBaseBytes);
+        expect(name.startsWith("你好世界")).toBe(true);
         expect(name.length).toBeGreaterThan(0);
     });
 


### PR DESCRIPTION
## Summary

- preserve leading non-ASCII letters when generating conversation filenames;
- keep the existing removal of unsafe leading punctuation; and
- add regression coverage for Cyrillic and Chinese titles.

## Root cause

The filename sanitizer used JavaScript's `\w` character class to decide which leading characters were safe. Because `\w` is ASCII-only, titles beginning with Cyrillic or other Unicode letters were stripped until an ASCII character was reached.

The sanitizer now uses Unicode letter and number properties, so a title such as `Ошибка Ambiguous project name` remains intact.

## User impact

Exported Markdown filenames now match their full conversation titles for non-ASCII scripts, and generated index links point to the correct filenames.

## Validation

- `npm run test:run` — 237 tests passed
- `npm run type-check`
- `npm run build`
- `npm run lint:strict` — 0 errors

Closes #68.
