### PR TITLE
fix: import OpenAI Privacy Portal archives

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -63,6 +63,10 @@ import {
 import { sortFilesForImport } from "./utils/file-sort";
 import { createZipArchiveReader } from "./utils/zip-loader";
 import { classifyArchiveEntries } from "./utils/zip-content-reader";
+import {
+    expandOpenAiPrivacyPortalArchives,
+    includeOpenAiPrivacyPortalFileArchives,
+} from "./utils/privacy-portal-archive";
 
 interface ImportCheckpoint {
     operation: "import-all" | "selective-analysis" | "selective-import";
@@ -425,6 +429,34 @@ export default class NexusAiChatImporterPlugin extends Plugin {
             zipFiles = [zipFiles[0]];
         }
 
+        const privacyPortalExpansion = await expandOpenAiPrivacyPortalArchives(
+            zipFiles
+        );
+        zipFiles = privacyPortalExpansion.files;
+        if (privacyPortalExpansion.expandedContainerNames.length > 0) {
+            this.logger
+                .child("ImportFlow")
+                .debug("Expanded OpenAI Privacy Portal archive", {
+                    containerNames:
+                        privacyPortalExpansion.expandedContainerNames,
+                    innerArchiveCount: zipFiles.length,
+                });
+        }
+
+        if (isMobile && zipFiles.length > 1) {
+            this.logger
+                .child("ImportFlow")
+                .warn(
+                    "Mobile Privacy Portal import limited to the first conversation archive",
+                    {
+                        expandedArchiveCount: zipFiles.length,
+                        keptFileName: zipFiles[0].name,
+                    }
+                );
+            new Notice(t("notices.import_mobile_single_zip_only"));
+            zipFiles = [zipFiles[0]];
+        }
+
         const sortedZipFiles = sortFilesForImport(zipFiles);
         const lockedProvider = await this.resolveProviderLockFromSelection(
             sortedZipFiles
@@ -618,6 +650,10 @@ export default class NexusAiChatImporterPlugin extends Plugin {
             const filesToImport = files.filter((file) =>
                 conversationsByFile.has(file.name)
             );
+            const attachmentFiles = includeOpenAiPrivacyPortalFileArchives(
+                filesToImport,
+                files
+            );
             this.setImportCheckpoint({
                 operation: "import-all",
                 phase: "file-processing-start",
@@ -630,7 +666,9 @@ export default class NexusAiChatImporterPlugin extends Plugin {
                 provider,
                 filesToImport,
                 conversationsByFile,
-                operationReport
+                operationReport,
+                undefined,
+                attachmentFiles
             );
 
             // Write the consolidated report (always, even if some files failed)
@@ -1083,6 +1121,10 @@ export default class NexusAiChatImporterPlugin extends Plugin {
             const filesToImport = files.filter((file) =>
                 conversationsByFile.has(file.name)
             );
+            const attachmentFiles = includeOpenAiPrivacyPortalFileArchives(
+                filesToImport,
+                files
+            );
             const selectedExistingConversationIds =
                 this.collectSelectedExistingConversationIds(
                     result.selectedIds,
@@ -1102,7 +1144,8 @@ export default class NexusAiChatImporterPlugin extends Plugin {
                 filesToImport,
                 conversationsByFile,
                 operationReport,
-                selectedExistingConversationIds
+                selectedExistingConversationIds,
+                attachmentFiles
             );
 
             // Write the consolidated report (always, even if some files failed)
@@ -1585,13 +1628,21 @@ ${report.generateMobileIndexContent(files, links)}
         filesToImport: File[],
         conversationsByFile: Map<string, string[]>,
         operationReport: ImportReport,
-        selectedExistingConversationIds?: Set<string>
+        selectedExistingConversationIds?: Set<string>,
+        attachmentFiles?: File[]
     ): Promise<void> {
         const importFlowLogger = this.logger.child("ImportFlow");
         const mobileTaskQueueMode = this.isMobileTaskQueueMode();
         const executionFiles = mobileTaskQueueMode
             ? filesToImport.slice(0, 1)
             : filesToImport;
+        const attachmentFilesToScan = mobileTaskQueueMode
+            ? executionFiles
+            : attachmentFiles ?? executionFiles;
+        const shouldBuildMultiZipAttachmentMap =
+            !mobileTaskQueueMode &&
+            provider === "chatgpt" &&
+            attachmentFilesToScan.length > 1;
 
         if (mobileTaskQueueMode && filesToImport.length > 1) {
             importFlowLogger.warn(
@@ -1605,24 +1656,20 @@ ${report.generateMobileIndexContent(files, links)}
             );
         }
 
-        if (
-            !mobileTaskQueueMode &&
-            provider === "chatgpt" &&
-            executionFiles.length > 1
-        ) {
+        if (shouldBuildMultiZipAttachmentMap) {
             this.setImportCheckpoint({
                 operation,
                 phase: "attachment-map-build",
                 provider,
-                task: `0/${executionFiles.length}`,
+                task: `0/${attachmentFilesToScan.length}`,
             });
             importFlowLogger.debug(`Building multi-ZIP attachment map`, {
                 provider,
-                fileCount: executionFiles.length,
+                fileCount: attachmentFilesToScan.length,
                 mode: "desktop-multi-zip",
             });
             await this.importService.buildAttachmentMapForMultiZip(
-                executionFiles,
+                attachmentFilesToScan,
                 provider
             );
         }
@@ -1726,11 +1773,7 @@ ${report.generateMobileIndexContent(files, links)}
             }
         }
 
-        if (
-            !mobileTaskQueueMode &&
-            provider === "chatgpt" &&
-            executionFiles.length > 1
-        ) {
+        if (shouldBuildMultiZipAttachmentMap) {
             this.importService.clearAttachmentMap();
         }
     }

--- a/src/utils/privacy-portal-archive.test.ts
+++ b/src/utils/privacy-portal-archive.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it, vi } from "vitest";
+import JSZip from "jszip";
+import {
+    expandOpenAiPrivacyPortalArchives,
+    includeOpenAiPrivacyPortalFileArchives,
+    ZipReaderFactory,
+} from "./privacy-portal-archive";
+import {
+    createZipArchiveReader,
+    ZipArchiveReader,
+    ZipEntryHandle,
+    ZipEntryMeta,
+} from "./zip-loader";
+import { classifyArchiveEntries } from "./zip-content-reader";
+
+class MemoryEntry implements ZipEntryHandle {
+    constructor(readonly name: string, private readonly bytes: Uint8Array) {}
+
+    async readText(): Promise<string> {
+        return new TextDecoder().decode(this.bytes);
+    }
+
+    async readBytes(): Promise<Uint8Array> {
+        return this.bytes;
+    }
+}
+
+class MemoryReader implements ZipArchiveReader {
+    constructor(private readonly entries: Record<string, Uint8Array>) {}
+
+    async listEntries(): Promise<ZipEntryMeta[]> {
+        return Object.entries(this.entries).map(([path, bytes]) => ({
+            path,
+            size: bytes.byteLength,
+        }));
+    }
+
+    has(name: string): boolean {
+        return Object.prototype.hasOwnProperty.call(this.entries, name);
+    }
+
+    get(name: string): ZipEntryHandle | null {
+        const bytes = this.entries[name];
+        return bytes ? new MemoryEntry(name, bytes) : null;
+    }
+}
+
+function createFile(name: string, lastModified = 123): File {
+    return new File([new Uint8Array([1])], name, {
+        type: "application/zip",
+        lastModified,
+    });
+}
+
+class ArrayBufferFileReader {
+    result: ArrayBuffer | null = null;
+    error: Error | null = null;
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+
+    readAsArrayBuffer(blob: Blob): void {
+        void blob.arrayBuffer().then(
+            (buffer) => {
+                this.result = buffer;
+                this.onload?.();
+            },
+            (error: unknown) => {
+                this.error =
+                    error instanceof Error ? error : new Error(String(error));
+                this.onerror?.();
+            }
+        );
+    }
+}
+
+describe("OpenAI Privacy Portal archive expansion", () => {
+    it("leaves ordinary ChatGPT exports untouched without opening them", async () => {
+        const file = createFile("chatgpt-export.zip");
+        const readerFactory = vi.fn<ZipReaderFactory>();
+
+        const result = await expandOpenAiPrivacyPortalArchives(
+            [file],
+            readerFactory
+        );
+
+        expect(result.files).toEqual([file]);
+        expect(result.expandedContainerNames).toEqual([]);
+        expect(readerFactory).not.toHaveBeenCalled();
+    });
+
+    it("replaces a Privacy Portal container with its conversation and file archives", async () => {
+        const outer = createFile("chatgpt_archive_account.zip", 456);
+        const conversationName = "Conversations_account-chatgpt-0001.zip";
+        const filesName = "Files_account-files-0001.zip";
+        const outerReader = new MemoryReader({
+            [`User Online Activity/${conversationName}`]: new Uint8Array([2]),
+            [`User Online Activity/${filesName}`]: new Uint8Array([3]),
+            "report.html": new Uint8Array([4]),
+        });
+        const conversationReader = new MemoryReader({
+            "conversations.json": new TextEncoder().encode("[]"),
+        });
+        const filesReader = new MemoryReader({
+            "file-abc-document.pdf": new Uint8Array([5]),
+        });
+        const readerFactory = vi.fn<ZipReaderFactory>(async (file) => {
+            if (file === outer) return outerReader;
+            if (file.name === conversationName) return conversationReader;
+            if (file.name === filesName) return filesReader;
+            throw new Error(`Unexpected file: ${file.name}`);
+        });
+
+        const result = await expandOpenAiPrivacyPortalArchives(
+            [outer],
+            readerFactory
+        );
+
+        expect(result.files.map((file) => file.name)).toEqual([
+            conversationName,
+            filesName,
+        ]);
+        expect(result.files.every((file) => file.lastModified === 456)).toBe(
+            true
+        );
+        expect(result.expandedContainerNames).toEqual([outer.name]);
+    });
+
+    it("keeps the outer archive when no valid ChatGPT conversation archive is found", async () => {
+        const outer = createFile("chatgpt_archive_account.zip");
+        const conversationName = "Conversations_account-chatgpt-0001.zip";
+        const outerReader = new MemoryReader({
+            [`User Online Activity/${conversationName}`]: new Uint8Array([2]),
+        });
+        const invalidInnerReader = new MemoryReader({
+            "unrelated.json": new TextEncoder().encode("{}"),
+        });
+        const readerFactory = vi.fn<ZipReaderFactory>(async (file) =>
+            file === outer ? outerReader : invalidInnerReader
+        );
+
+        const result = await expandOpenAiPrivacyPortalArchives(
+            [outer],
+            readerFactory
+        );
+
+        expect(result.files).toEqual([outer]);
+        expect(result.expandedContainerNames).toEqual([]);
+    });
+
+    it("does not reserve inner filenames when an earlier container fails validation", async () => {
+        const invalidOuter = createFile("chatgpt_archive_invalid.zip", 1);
+        const validOuter = createFile("chatgpt_archive_valid.zip", 2);
+        const conversationName = "Conversations_account-chatgpt-0001.zip";
+        const outerReader = new MemoryReader({
+            [`User Online Activity/${conversationName}`]: new Uint8Array([2]),
+        });
+        const invalidInnerReader = new MemoryReader({
+            "unrelated.json": new TextEncoder().encode("{}"),
+        });
+        const validInnerReader = new MemoryReader({
+            "conversations.json": new TextEncoder().encode("[]"),
+        });
+        const readerFactory = vi.fn<ZipReaderFactory>(async (file) => {
+            if (file === invalidOuter || file === validOuter) {
+                return outerReader;
+            }
+            return file.lastModified === 1
+                ? invalidInnerReader
+                : validInnerReader;
+        });
+
+        const result = await expandOpenAiPrivacyPortalArchives(
+            [invalidOuter, validOuter],
+            readerFactory
+        );
+
+        expect(result.files.map((file) => file.name)).toEqual([
+            invalidOuter.name,
+            conversationName,
+        ]);
+        expect(result.expandedContainerNames).toEqual([validOuter.name]);
+    });
+
+    it("includes Privacy Portal file archives in attachment lookup without duplicating imports", () => {
+        const conversations = createFile(
+            "Conversations_account-chatgpt-0001.zip"
+        );
+        const attachments = createFile("Files_account-files-0001.zip");
+
+        expect(
+            includeOpenAiPrivacyPortalFileArchives(
+                [conversations],
+                [conversations, attachments]
+            )
+        ).toEqual([conversations, attachments]);
+        expect(
+            includeOpenAiPrivacyPortalFileArchives(
+                [conversations, attachments],
+                [conversations, createFile("Files_account-files-0001.zip")]
+            )
+        ).toEqual([conversations, attachments]);
+    });
+
+    it("produces inner files that remain readable by the real ZIP reader", async () => {
+        const conversationName = "Conversations_account-chatgpt-0001.zip";
+        const innerZip = new JSZip();
+        innerZip.file("conversations.json", "[]");
+        const innerBytes = await innerZip.generateAsync({
+            type: "uint8array",
+            compression: "DEFLATE",
+        });
+
+        const outerZip = new JSZip();
+        outerZip.file(`User Online Activity/${conversationName}`, innerBytes);
+        outerZip.file("report.html", "<html></html>");
+        const outerBytes = await outerZip.generateAsync({
+            type: "uint8array",
+            compression: "DEFLATE",
+        });
+        const outerFile = new File(
+            [
+                outerBytes.buffer.slice(
+                    outerBytes.byteOffset,
+                    outerBytes.byteOffset + outerBytes.byteLength
+                ) as ArrayBuffer,
+            ],
+            "chatgpt_archive_account.zip",
+            { type: "application/zip" }
+        );
+        vi.stubGlobal("FileReader", ArrayBufferFileReader);
+
+        try {
+            const result = await expandOpenAiPrivacyPortalArchives([outerFile]);
+            expect(result.files.map((file) => file.name)).toEqual([
+                conversationName,
+            ]);
+
+            const reader = await createZipArchiveReader(result.files[0]);
+            const entries = await reader.listEntries();
+            expect(
+                classifyArchiveEntries(entries.map((entry) => entry.path))
+            ).toMatchObject({
+                supported: true,
+                provider: "chatgpt",
+            });
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+});

--- a/src/utils/privacy-portal-archive.ts
+++ b/src/utils/privacy-portal-archive.ts
@@ -1,0 +1,196 @@
+import { createZipArchiveReader, ZipArchiveReader } from "./zip-loader";
+import { classifyArchiveEntries } from "./zip-content-reader";
+
+export type ZipReaderFactory = (file: File) => Promise<ZipArchiveReader>;
+
+export interface PrivacyPortalArchiveExpansionResult {
+    files: File[];
+    expandedContainerNames: string[];
+}
+
+const PRIVACY_PORTAL_CONTAINER_PATTERN = /^chatgpt_archive(?:_.+)?\.zip$/i;
+const PRIVACY_PORTAL_CONVERSATION_PATTERN =
+    /^Conversations_.+-chatgpt-\d+(?: \(\d+\))?\.zip$/i;
+const PRIVACY_PORTAL_FILES_PATTERN = /^Files_.+-files-\d+(?: \(\d+\))?\.zip$/i;
+
+function getBaseName(path: string): string {
+    return path.split("/").pop() ?? path;
+}
+
+function isPrivacyPortalInnerArchive(path: string): boolean {
+    const baseName = getBaseName(path);
+    return (
+        PRIVACY_PORTAL_CONVERSATION_PATTERN.test(baseName) ||
+        PRIVACY_PORTAL_FILES_PATTERN.test(baseName)
+    );
+}
+
+function isConversationArchive(file: File): boolean {
+    return PRIVACY_PORTAL_CONVERSATION_PATTERN.test(file.name);
+}
+
+export function isOpenAiPrivacyPortalFilesArchive(file: File): boolean {
+    return PRIVACY_PORTAL_FILES_PATTERN.test(file.name);
+}
+
+export function includeOpenAiPrivacyPortalFileArchives(
+    importFiles: File[],
+    selectedFiles: File[]
+): File[] {
+    const result = [...importFiles];
+    const includedNames = new Set(importFiles.map((file) => file.name));
+
+    for (const file of selectedFiles) {
+        if (
+            isOpenAiPrivacyPortalFilesArchive(file) &&
+            !includedNames.has(file.name)
+        ) {
+            result.push(file);
+            includedNames.add(file.name);
+        }
+    }
+
+    return result;
+}
+
+function toFilePart(bytes: Uint8Array): ArrayBuffer {
+    return bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength
+    ) as ArrayBuffer;
+}
+
+function makeUniqueFileName(name: string, usedNames: Set<string>): string {
+    if (!usedNames.has(name)) {
+        usedNames.add(name);
+        return name;
+    }
+
+    const extensionIndex = name.toLowerCase().lastIndexOf(".zip");
+    const stem = extensionIndex >= 0 ? name.slice(0, extensionIndex) : name;
+    const extension = extensionIndex >= 0 ? name.slice(extensionIndex) : "";
+    let counter = 2;
+    let candidate = `${stem} (${counter})${extension}`;
+    while (usedNames.has(candidate)) {
+        counter++;
+        candidate = `${stem} (${counter})${extension}`;
+    }
+
+    usedNames.add(candidate);
+    return candidate;
+}
+
+async function expandPrivacyPortalContainer(
+    file: File,
+    readerFactory: ZipReaderFactory,
+    usedNames: Set<string>
+): Promise<File[] | null> {
+    if (!PRIVACY_PORTAL_CONTAINER_PATTERN.test(file.name)) {
+        return null;
+    }
+
+    try {
+        const pendingUsedNames = new Set(usedNames);
+        const outerReader = await readerFactory(file);
+        const entries = await outerReader.listEntries();
+        const innerEntries = entries
+            .filter((entry) => isPrivacyPortalInnerArchive(entry.path))
+            .sort((a, b) => {
+                const aConversation = PRIVACY_PORTAL_CONVERSATION_PATTERN.test(
+                    getBaseName(a.path)
+                );
+                const bConversation = PRIVACY_PORTAL_CONVERSATION_PATTERN.test(
+                    getBaseName(b.path)
+                );
+                if (aConversation !== bConversation) {
+                    return aConversation ? -1 : 1;
+                }
+                return a.path.localeCompare(b.path);
+            });
+
+        if (innerEntries.length === 0) {
+            return null;
+        }
+
+        const innerFiles: File[] = [];
+        for (const entry of innerEntries) {
+            const handle = outerReader.get(entry.path);
+            if (!handle) {
+                return null;
+            }
+
+            const bytes = await handle.readBytes();
+            const name = makeUniqueFileName(
+                getBaseName(entry.path),
+                pendingUsedNames
+            );
+            innerFiles.push(
+                new File([toFilePart(bytes)], name, {
+                    type: "application/zip",
+                    lastModified: file.lastModified,
+                })
+            );
+        }
+
+        const conversationFiles = innerFiles.filter(isConversationArchive);
+        if (conversationFiles.length === 0) {
+            return null;
+        }
+
+        for (const conversationFile of conversationFiles) {
+            const innerReader = await readerFactory(conversationFile);
+            const innerEntries = await innerReader.listEntries();
+            const classification = classifyArchiveEntries(
+                innerEntries.map((entry) => entry.path)
+            );
+            if (
+                !classification.supported ||
+                classification.provider !== "chatgpt"
+            ) {
+                return null;
+            }
+        }
+
+        for (const innerFile of innerFiles) {
+            usedNames.add(innerFile.name);
+        }
+
+        return innerFiles;
+    } catch {
+        return null;
+    }
+}
+
+export async function expandOpenAiPrivacyPortalArchives(
+    files: File[],
+    readerFactory: ZipReaderFactory = createZipArchiveReader
+): Promise<PrivacyPortalArchiveExpansionResult> {
+    const expandedFiles: File[] = [];
+    const expandedContainerNames: string[] = [];
+    const usedNames = new Set(
+        files
+            .filter((file) => !PRIVACY_PORTAL_CONTAINER_PATTERN.test(file.name))
+            .map((file) => file.name)
+    );
+
+    for (const file of files) {
+        const innerFiles = await expandPrivacyPortalContainer(
+            file,
+            readerFactory,
+            usedNames
+        );
+        if (!innerFiles) {
+            expandedFiles.push(file);
+            usedNames.add(file.name);
+            continue;
+        }
+
+        expandedFiles.push(...innerFiles);
+        expandedContainerNames.push(file.name);
+    }
+
+    return {
+        files: expandedFiles,
+        expandedContainerNames,
+    };
+}


### PR DESCRIPTION
## Summary

- detect OpenAI Privacy Portal containers named `chatgpt_archive*.zip`
- extract their known `Conversations_*-chatgpt-*.zip` and `Files_*-files-*.zip` entries
- validate every nested conversation archive as a real ChatGPT export before replacing the outer archive
- include Privacy Portal file archives in the desktop multi-ZIP attachment lookup while keeping them out of conversation processing

## Root cause

The import flow only classified entries at the root of the selected ZIP. Privacy Portal downloads wrap the supported ChatGPT conversation ZIP inside an account-level archive, so the root contained nested ZIP files instead of `conversations.json` and was rejected as unsupported.

## Safety and compatibility

- ordinary ChatGPT exports are returned untouched without an extra ZIP scan
- only the documented Privacy Portal container and inner archive naming patterns are expanded
- unreadable or invalid nested conversation archives leave the outer archive unchanged, preserving the existing guidance instead of partially importing data
- duplicate inner filenames are made unique without allowing a failed container to reserve names
- the existing mobile single-archive guard remains in force

Fixes #67.

## Validation

- `npm run test:run` — 242 tests passed
- `npm run type-check`
- `npx eslint src/main.ts src/utils/privacy-portal-archive.ts src/utils/privacy-portal-archive.test.ts`
- `npm run build`

The regression suite includes a real DEFLATE-compressed nested ZIP round trip through the production ZIP reader.