### PR TITLE
fix(claude): keep messages whose only content is an attachment

### DIFF
--- a/src/models/import-report.ts
+++ b/src/models/import-report.ts
@@ -410,6 +410,13 @@ export class ImportReport {
             } |`
         );
         lines.push(`| Failed | ${stats.failed} |`);
+        // Conversations that carried no content are dropped without a note.
+        // Without this row they vanish from the summary entirely, so a run
+        // that imported a fraction of the archive still reads as a clean run.
+        const ignoredCount = this.getIgnoredCount();
+        if (ignoredCount > 0) {
+            lines.push(`| 🚫 Empty (ignored) | ${ignoredCount} |`);
+        }
         if (analysisInfo) {
             lines.push(
                 `| Found (raw) | ${analysisInfo.totalConversationsFound || 0} |`

--- a/src/providers/claude/claude-converter.test.ts
+++ b/src/providers/claude/claude-converter.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { ClaudeConverter } from "./claude-converter";
+import type { ClaudeConversation, ClaudeMessage } from "./claude-types";
+
+/**
+ * Minimal plugin stub. Attachment-only messages do not exercise artifact or
+ * ZIP extraction, so a logger is all the converter needs on these paths.
+ */
+const logger = {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    child: () => logger,
+};
+const pluginStub = { logger } as never;
+
+function message(overrides: Partial<ClaudeMessage>): ClaudeMessage {
+    return {
+        uuid: "m-1",
+        text: "",
+        sender: "human",
+        created_at: "2025-01-01T00:00:00.000Z",
+        content: [],
+        attachments: [],
+        files: [],
+        ...overrides,
+    };
+}
+
+function conversation(messages: ClaudeMessage[]): ClaudeConversation {
+    return {
+        uuid: "c-1",
+        name: "",
+        account: { uuid: "a-1" },
+        created_at: "2025-01-01T00:00:00.000Z",
+        updated_at: "2025-01-01T00:00:00.000Z",
+        chat_messages: messages,
+    };
+}
+
+describe("ClaudeConverter attachment-only messages", () => {
+    beforeAll(() => {
+        ClaudeConverter.setPlugin(pluginStub);
+    });
+
+    it("keeps a message whose only content is an uploaded document", async () => {
+        const chat = conversation([
+            message({
+                uuid: "m-doc",
+                attachments: [
+                    {
+                        file_name: "brief.pdf",
+                        file_size: 1234,
+                        file_type: "application/pdf",
+                    },
+                ] as never,
+            }),
+        ]);
+
+        const result = await ClaudeConverter.convertChat(chat);
+
+        expect(result.messages).toHaveLength(1);
+    });
+
+    it("keeps a message whose only content is an uploaded file", async () => {
+        const chat = conversation([
+            message({
+                uuid: "m-file",
+                files: [{ file_name: "photo.png" }] as never,
+            }),
+        ]);
+
+        const result = await ClaudeConverter.convertChat(chat);
+
+        expect(result.messages).toHaveLength(1);
+    });
+
+    it("still drops a message with no text, content, attachments or files", async () => {
+        const chat = conversation([message({ uuid: "m-empty" })]);
+
+        const result = await ClaudeConverter.convertChat(chat);
+
+        expect(result.messages).toHaveLength(0);
+    });
+
+    it("keeps text-only messages as before", async () => {
+        const chat = conversation([message({ uuid: "m-text", text: "hello" })]);
+
+        const result = await ClaudeConverter.convertChat(chat);
+
+        expect(result.messages).toHaveLength(1);
+    });
+});

--- a/src/providers/claude/claude-converter.ts
+++ b/src/providers/claude/claude-converter.ts
@@ -441,10 +441,16 @@ export class ClaudeConverter {
     private static shouldIncludeMessage(message: ClaudeMessage): boolean {
         // Include all human and assistant messages
         if (message.sender === "human" || message.sender === "assistant") {
-            // Skip empty messages
+            // Skip messages that carry nothing at all. A message with no text
+            // and no content blocks can still be meaningful: uploading a file
+            // with no caption produces an empty text plus an `attachments` or
+            // `files` entry, and dropping it silently loses the whole
+            // conversation when every message looks like that.
             if (
                 !message.text &&
-                (!message.content || message.content.length === 0)
+                (!message.content || message.content.length === 0) &&
+                (!message.attachments || message.attachments.length === 0) &&
+                (!message.files || message.files.length === 0)
             ) {
                 return false;
             }


### PR DESCRIPTION
## The bug

A Claude message with no typed text but an uploaded file arrives as:

```json
{ "text": "", "content": [], "attachments": [{...}], "files": [] }
```

`ClaudeConverter.shouldIncludeMessage()` only inspected `text` and `content`, so it dropped the message. When *every* message in a conversation looks like that, `convertChat()` returns zero messages and `ConversationProcessor.createNewNote()` returns early via `addIgnored()` without writing a note.

## Why it was hard to spot

The drop is silent. `addIgnored()` records the conversation, but the consolidated summary never rendered the ignored count — so an import that wrote 66 notes out of 1510 selected conversations still reported `Skipped 0` and `Failed 0`. Nothing in the report accounted for the missing 1444.

This PR also adds the `🚫 Empty (ignored)` row to the consolidated summary so the numbers reconcile.

## Measurements

Real Claude export, 1547 conversations, imported into a scratch folder:

| | before | after |
|---|---:|---:|
| notes written | 66 | **210** |

210 is exactly the number of conversations in that archive containing anything at all (47 text-only + 19 text+attachment + **144 attachment-only**). The 144 attachment-only conversations are what this fix recovers.

Report after the fix — the numbers now add up (210 + 1300 = 1510):

```
| Created            |  210 |
| Failed             |    0 |
| 🚫 Empty (ignored) | 1300 |
| Found (raw)        | 1510 |
```

## Note on the remaining 1300

Those conversations are empty in the export itself — every message has `text: ""`, `content: []`, `attachments: []`, `files: []`. This is not something the plugin can recover, but it is worth flagging for other users: comparing a December 2024 export against a 2026 export of the same account, 275 of 287 shared conversations had full message text in the older file and empty text in the newer one, for identical message UUIDs. Whatever causes that is upstream of the plugin. Surfacing the ignored count at least makes it visible instead of looking like a clean import.

## Tests

New `src/providers/claude/claude-converter.test.ts` covers attachment-only, file-only, fully-empty, and text-only messages. It fails on `master` and passes with the fix.

`npm run type-check` clean. Full suite: 248 passed, 1 pre-existing failure in `vibe-report-naming.test.ts` (`should handle timestamp in milliseconds` — a timezone-dependent assertion that also fails on an unmodified checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WRAvsVQPUWFV1UUrzuEzj